### PR TITLE
Reduce padding between links to variants on small screens

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -706,6 +706,9 @@ ul.guide li {
     font-size: 1rem;
     margin: 0;
   }
+  ul.guide li a {
+    padding: 8px 0px;
+  }
 }
 .login.nav-link {
   align-self: center;


### PR DESCRIPTION
Reduce top and bottom padding by 1/3 and remove padding-right that caused "KOTH 960" to take two lines